### PR TITLE
remove create_venv, lint all code, other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # venv_manager: Manage your python virtual environments without any effort. Literally.
 
-![Look, a moving picture!](https://github.com/purajit/venv_manager/blob/master/demo.gif "Demo")
+![Demo](https://github.com/purajit/venv_manager/blob/master/demo.gif "Demo")
 
 Have multiple python virtual environments and find it annoying to manage them? Ever
 install PyPI packages into the wrong environment or otherwise make modifications you
@@ -8,63 +8,39 @@ meant to make to some other environment? Then this plugin is for you!
 
 This plugin helps you create and change/activate/deactivate python virtual
 environments depending on your current path. It searches through each parent in the
-working directory for the folder `$VENV_DIR` (by default ".venv"). If it exists,
-it sources its activation script (after deactivating the current virtualenv, if there
-is one). If it doesn't, then it just deactivates the current environment if there is
-one, leaving you in a non-virtual environment.
-
-(Currently works with `zsh` and `bash`; specifically written for oh-my-zsh but extendable)
+working directory for the folder `$VENV_DIR`, and activates the closest one,
+or deactivates the active venv if you have left its context.
 
 ## Installation
 
-* `zsh`: clone into `custom/plugins` in your oh-my-zsh folder, and add "venv_manager"
-  to your list of plugins in your `.zshrc`. If you're not using oh-my-zsh, you can
-  simply `source` it.
-* `bash`: clone anywhere, `source` it from `.bashrc`.
-* Others: if you want to add support for other shells, I'm open to accepting changes
-  for it.
+* `oh-my-zsh`: clone into `custom/plugins` in your `oh-my-zsh` folder, and add `venv_manager`
+  to the list of plugins in your `.zshrc`.
+* otherwise, clone anywhere, `source` it from your shell rc.
 
-In addition, I set
+This makes the command `venv_manager_switch_venv` available to use.
 
-    export VIRTUAL_ENV_DISABLE_PROMPT=1
+Add the following to your shell rc for automatic switching:
+```sh
+# zsh
+precmd() {
+  venv_manager_switch_venv
+}
 
-to disable virtualenv from messing with my prompt and instead use my own function
-that shows the _parent_ of the virtualenv directory, which I find more useful:
+# bash
+export PROMPT_COMMAND=venv_manager_switch_venv
+```
 
-    # get parent folder of virtualenv location
-    function get_python_venv {
-        if [[ -n "$VIRTUAL_ENV" ]] ; then
-            echo "($(basename -- "$(dirname -- "$VIRTUAL_ENV")")) "
-        fi
-    }
-
-and incorporate it into my prompt:
-
-    PROMPT="$(get_python_venv) ...
+You can configure `$VENV_DIR`, which defaults to `.venv`
 
 ## Usage
 
-Try it out! Simply `cd` in and out of folders that have virtual environments! It
-assumes that all your virtual environment folders have the same name, `$VENV_DIR`. To
-define your own name, set it in your shell config. If unset, it assumes you use
-`".venv"`.
-
-To create a new virtual environment, run `create_venv <path>`. If `<path>` is not
-provided, it creates it in the current working directory. You can also provide all
-the usual virtualenv options, such as the path to the python interpreter. This helps
-you create virtual environments that follow the naming convention assumed by the plugin.
-
-## Contributing
-
-1. Fork it!
-2. Create your feature branch: `git checkout -b my-new-feature`
-3. Commit your changes: `git commit -am 'Add some feature'`
-4. Push to the branch: `git push origin my-new-feature`
-5. Submit a pull request :D
+Try it out! Simply `cd` in and out of folders that have virtual environments!
 
 ## History
 
 21 March, 2017: created repository.
+
+05 September, 2024: several updates now that I'm a more mature, grounded individual.
 
 ## Credits
 

--- a/venv_manager.plugin.zsh
+++ b/venv_manager.plugin.zsh
@@ -1,100 +1,34 @@
 ## Plugin to create/change/activate/deactivate python virtual environment depending
 ## on the current path. Searches through each parent in PWD for the folder
-## $VENV_DIR (by default \".venv\"). If it exists, it sources its activation
-## script (after deactivating current virtualenv, if there is one). If it doesn't,
-## then it just deactivates the current environment if there is one, leaving you in
-## a non-virtual environment.
+## $VENV_DIR (by default ".venv"), and activates it appropriately.
 
 _OLD_PWD="/"
-if [ -z "$VENV_DIR" ]; then
-    export VENV_DIR=".venv"
-fi
+: "${VENV_DIR:=.venv}"
 
-function check_for_venv() {
-    cur_dir=$(pwd)
-
-    if [ -d $cur_dir/$VENV_DIR ]; then
-        echo $cur_dir/$VENV_DIR
+function venv_manager_switch_venv() {
+    if [ "$_OLD_PWD" = "$(pwd)" ]; then
+        if [ ! -d "$VIRTUAL_ENV" ]; then
+            command -v deactivate &> /dev/null && deactivate_venv
+        fi
         return
     fi
 
-    while [ 1 ]
-    do
-        cur_dir=$(dirname $cur_dir)
+    _OLD_PWD="$(pwd)"
 
-        if [ -d $cur_dir/$VENV_DIR ]; then
-            echo $cur_dir/$VENV_DIR
-            return
-        fi
+    new_venv=""
+    cur_dir="$(pwd)"
 
-        if [ $cur_dir = "/" ]; then
-            return
+    while [ "$cur_dir" != "/" ]; do
+        if [ -d "${cur_dir}/${VENV_DIR}" ]; then
+            new_venv="${cur_dir}/${VENV_DIR}"
+            break
         fi
+        cur_dir="$(dirname "$cur_dir")"
     done
-}
 
-function deactivate_venv() {
-    echo Deactivating virtual environment in $(dirname $VIRTUAL_ENV) "..."
-    deactivate
-}
-
-function activate_venv() {
-    source $1/bin/activate
-    if [ x"$2" = "xafter_deactivate" ]; then
-        echo "..." and entering virtual environment in $(dirname $1) "..."
+    if [ -n "$new_venv" ]; then
+        source "$new_venv/bin/activate"
     else
-        echo Entering virtual environment in $(dirname $1) "..."
+        command -v deactivate &> /dev/null && deactivate
     fi
 }
-
-function change_venv_if_needed() {
-    if [ x"$1" != "xignore_pwd" -a "$_OLD_PWD" = "$(pwd)" ]; then
-        if [ ! -d $VIRTUAL_ENV ]; then
-            deactivate_venv
-        fi
-        return
-    fi
-
-    _OLD_PWD=$(pwd)
-
-    new_venv=$(check_for_venv)
-
-    if [ -z $VIRTUAL_ENV ]; then
-        # no venv previously, but new one exists
-        if [ -n "$new_venv" ]; then
-            activate_venv $new_venv
-        fi
-    else
-        # going from venv to non-venv environment
-        if [ -z "$new_venv" ]; then
-            deactivate_venv
-        # switching venv environments
-        elif [ $new_venv != $VIRTUAL_ENV ]; then
-            deactivate_venv
-            activate_venv $new_venv after_deactivate
-        fi
-    fi
-}
-
-function create_venv() {
-    if [ -z "$1" ]; then
-        virtualenv $VENV_DIR
-        change_venv_if_needed ignore_pwd
-    elif [ ! -d $1 ]; then
-        virtualenv $VENV_DIR $@
-        change_venv_if_needed ignore_pwd
-    else
-        virtualenv $1/$VENV_DIR ${@:2}
-        change_venv_if_needed ignore_pwd
-    fi
-}
-
-case "$0" in
-    *zsh*)
-        precmd() {
-            change_venv_if_needed
-        }
-        ;;
-    *bash*)
-        export PROMPT_COMMAND=change_venv_if_needed
-esac


### PR DESCRIPTION
Don't change precmd/prompt_command on sourcing, allow the user to do it.
Put everything into one function to avoid as much leakage as possible.
Remove create_venv, there are better tools (`uv venv`).
Why did I have so much code? Most of it wasn't needed.